### PR TITLE
Upgrade to 1.4.0 (Past types and subcommand rename)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pokelookup"
-version = "1.3.5"
+version = "1.4.0"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "rustemon"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed75e7f56ac6800f4aa38b2495b2b05901cd680f6791eb3b1e76b91c5ef7bcde"
+checksum = "6311a9af7c35f1c09bb0db8c1a4c5f5e73da1c373a36721ca2c8ad7c21ce08f3"
 dependencies = [
  "http-cache-reqwest",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pokelookup"
 description = "Look up pokemon details through PokeAPI."
 authors = ["Justin Marquez"]
-version = "1.3.5"
+version = "1.4.0"
 edition = "2024"
 readme = "README.md"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.43", features = ["derive"] }
 futures = "0.3.31"
 itertools = "0.14.0"
 open = { version = "5.3.2", optional = true }
-rustemon = "4.4.0"
+rustemon = "4.5.0"
 serde_json = "1.0.142"
 tokio = { version="1.47.1", features=["full"] }
 ureq = "3.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.43", features = ["derive"] }
 futures = "0.3.31"
 itertools = "0.14.0"
 open = { version = "5.3.2", optional = true }
-rustemon = "4.5.0"
+rustemon = "=4.5.0"
 serde_json = "1.0.142"
 tokio = { version="1.47.1", features=["full"] }
 ureq = "3.0.12"

--- a/src/lookup/abilities.rs
+++ b/src/lookup/abilities.rs
@@ -41,7 +41,7 @@ pub async fn print_abilities(
   for mon_resource in resources.iter() {
     // Get ability resources
     let abilities = match future::try_join_all(mon_resource.abilities.iter().map(async |a| {
-      match a.ability.follow(client).await {
+      match a.ability.clone().unwrap().follow(client).await {
         Ok(x) => Ok(Ability {
           hidden: a.is_hidden,
           ability: x,

--- a/src/lookup/types.rs
+++ b/src/lookup/types.rs
@@ -9,6 +9,7 @@ use rustemon::client::RustemonClient;
 pub async fn print_types(
   client: &RustemonClient,
   pokemon: &str,
+  generation: Option<i64>,
   fast: bool,
   lang: LanguageId,
   recursive: bool,
@@ -41,6 +42,22 @@ pub async fn print_types(
         item.type_.name.clone()
       });
     }
+    if let Some(generation) = generation {
+      for past_item in mon_resource.past_types.iter() {
+        if let Ok(x) = past_item.generation.follow(client).await
+          && x.id >= generation
+        {
+          type_names.clear();
+          for item in past_item.types.iter() {
+            type_names.push(if !fast {
+              get_name!(follow item.type_, client, lang.to_string())
+            } else {
+              item.type_.name.clone()
+            });
+          }
+        }
+      }
+    }
 
     // Return types
     result.push(format!(
@@ -72,10 +89,41 @@ mod tests {
 
     for fast in [false, true].into_iter() {
       let pokemon = String::from("toxel");
+      let generation = None;
       let lang = LanguageId::En;
       let recursive = false;
 
-      match print_types(&client, &pokemon, fast, lang, recursive).await {
+      match print_types(&client, &pokemon, generation, fast, lang, recursive).await {
+        Ok(s) => assert_eq!(
+          s,
+          if fast {
+            success.iter().map(|x| x.to_lowercase()).collect()
+          } else {
+            success.clone()
+          }
+        ),
+        Err(err) => panic!("{}", err.render()),
+      }
+    }
+  }
+
+  #[tokio::test]
+  async fn test_past_types() {
+    let client = RustemonClient::default();
+
+    let success: Vec<String> = vec!["jigglypuff:", "  normal"]
+      .into_iter()
+      .map(|x| x.into())
+      .collect();
+
+    for generation in 1..=5 {
+      let pokemon = String::from("jigglypuff");
+      let generation = Some(generation);
+      let fast = true;
+      let lang = LanguageId::En;
+      let recursive = false;
+
+      match print_types(&client, &pokemon, generation, fast, lang, recursive).await {
         Ok(s) => assert_eq!(
           s,
           if fast {
@@ -95,11 +143,12 @@ mod tests {
 
     let success = vec!["stantler:", "  normal", "wyrdeer:", "  normal/psychic"];
     let pokemon = String::from("stantler");
+    let generation = None;
     let fast = true;
     let lang = LanguageId::En;
     let recursive = true;
 
-    match print_types(&client, &pokemon, fast, lang, recursive).await {
+    match print_types(&client, &pokemon, generation, fast, lang, recursive).await {
       Ok(s) => assert_eq!(s, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,10 @@ async fn main() {
     SubArgs::TypeCmd {
       pokemon,
       fast,
+      generation,
       lang,
       recursive,
-    } => lookup::print_types(&client, &pokemon, fast, lang, recursive).await,
+    } => lookup::print_types(&client, &pokemon, generation, fast, lang, recursive).await,
     SubArgs::AbilityCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn main() {
       lang,
     } => lookup::print_matchups(&client, primary, secondary, list, fast, lang).await,
     #[cfg(feature = "web")]
-    SubArgs::SearchCmd {
+    SubArgs::WebCmd {
       endpoint,
       generation,
       area,

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -69,6 +69,9 @@ pub enum SubArgs {
     #[arg(short, long, help = "skip API requests for formatted names")]
     fast: bool,
 
+    #[arg(short, long = "gen", help = "generation to query")]
+    generation: Option<i64>,
+
     #[arg(value_enum,
       short = 'L',
       long,

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -278,8 +278,8 @@ pub enum SubArgs {
 
   /// Open web pages for a given endpoint. A valid endpoint includes pokemon, abilities, items, and more.
   #[cfg(feature = "web")]
-  #[command(name = "search", long_about)]
-  SearchCmd {
+  #[command(name = "web", long_about)]
+  WebCmd {
     #[command(flatten)]
     endpoint: Endpoints,
 


### PR DESCRIPTION
- Upgrade rustemon to `=4.5.0`
- Add past type lookup with optional `-g/--gen` argument
- Change `search` subcommand to `web` to better reflect its functionality