### PR TITLE
Lookup method refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pokelookup"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pokelookup"
 description = "Look up pokemon details through PokeAPI."
 authors = ["Justin Marquez"]
-version = "1.4.2"
+version = "1.4.3"
 edition = "2024"
 readme = "README.md"
 license = "MIT"

--- a/src/lookup/abilities.rs
+++ b/src/lookup/abilities.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, AbilityArgs};
+use crate::utils::args::AbilityArgs;
+use crate::utils::cli;
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use futures::future;

--- a/src/lookup/abilities.rs
+++ b/src/lookup/abilities.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::LanguageId;
+use crate::utils::cli::{self, AbilityArgs};
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use futures::future;
@@ -9,21 +8,20 @@ use rustemon::client::RustemonClient;
 
 pub async fn print_abilities(
   client: &RustemonClient,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
-  recursive: bool,
+  args: AbilityArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon resources
-  let resources = match helpers::get_pokemon_from_chain(client, pokemon, recursive).await {
+  let resources = match helpers::get_pokemon_from_chain(client, &args.pokemon, args.recursive).await
+  {
     Ok(x) => x,
     Err(_) => {
       let valid = cli::VALID;
       let err = cli::error(
         ErrorKind::InvalidValue,
         format!(
-          "invalid pokemon: {pokemon}\n\n{valid}tip:{valid:#} try running '{} list {pokemon}'",
-          cli::get_appname()
+          "invalid pokemon: {1}\n\n{valid}tip:{valid:#} try running '{} list {}'",
+          cli::get_appname(),
+          args.pokemon,
         ),
       );
       return Err(err);
@@ -66,8 +64,9 @@ pub async fn print_abilities(
     // Get ability names
     let mut names = Vec::new();
     for ab in abilities.into_iter() {
-      names.push(if !fast {
-        get_name!(ab.ability, client, lang.to_string()) + if ab.hidden { " (Hidden)" } else { "" }
+      names.push(if !args.fast {
+        get_name!(ab.ability, client, args.lang.to_string())
+          + if ab.hidden { " (Hidden)" } else { "" }
       } else {
         ab.ability.name.clone() + if ab.hidden { " (hidden)" } else { "" }
       });
@@ -76,8 +75,8 @@ pub async fn print_abilities(
     // Return abilities
     result.push(format!(
       "{}:",
-      if !fast {
-        helpers::get_pokemon_name(client, mon_resource, &lang.to_string()).await
+      if !args.fast {
+        helpers::get_pokemon_name(client, mon_resource, &args.lang.to_string()).await
       } else {
         mon_resource.name.clone()
       }
@@ -94,6 +93,7 @@ pub async fn print_abilities(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::LanguageId;
 
   #[tokio::test]
   async fn test_abilities() {
@@ -105,11 +105,14 @@ mod tests {
       .collect();
 
     for fast in [false, true].into_iter() {
-      let pokemon = String::from("toxel");
-      let lang = LanguageId::En;
-      let recursive = false;
+      let args = AbilityArgs {
+        pokemon: String::from("toxel"),
+        fast,
+        lang: LanguageId::En,
+        recursive: false,
+      };
 
-      match print_abilities(&client, &pokemon, fast, lang, recursive).await {
+      match print_abilities(&client, args).await {
         Ok(s) => assert_eq!(
           s,
           if fast {
@@ -132,12 +135,14 @@ mod tests {
       " 1. Intimidate", " 2. Frisk", " 3. Sap Sipper (Hidden)",
     ];
 
-    let pokemon = String::from("stantler");
-    let fast = false;
-    let lang = LanguageId::En;
-    let recursive = true;
+    let args = AbilityArgs {
+      pokemon: String::from("stantler"),
+      fast: false,
+      lang: LanguageId::En,
+      recursive: true,
+    };
 
-    match print_abilities(&client, &pokemon, fast, lang, recursive).await {
+    match print_abilities(&client, args).await {
       Ok(s) => assert_eq!(s, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/lookup/eggs.rs
+++ b/src/lookup/eggs.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, EggArgs};
+use crate::utils::args::EggArgs;
+use crate::utils::cli;
 use clap::error::ErrorKind;
 use futures::future;
 use rustemon::Follow;

--- a/src/lookup/eggs.rs
+++ b/src/lookup/eggs.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::LanguageId;
+use crate::utils::cli::{self, EggArgs};
 use clap::error::ErrorKind;
 use futures::future;
 use rustemon::Follow;
@@ -9,17 +8,15 @@ use rustemon::pokemon::*;
 
 pub async fn print_eggs(
   client: &RustemonClient,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
+  args: EggArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon species resource
-  let species = match pokemon_species::get_by_name(&pokemon.replace(" ", "-"), client).await {
+  let species = match pokemon_species::get_by_name(&args.pokemon.replace(" ", "-"), client).await {
     Ok(x) => x,
     Err(_) => {
       return Err(cli::error(
         ErrorKind::InvalidValue,
-        format!("invalid pokemon species: {pokemon}"),
+        format!("invalid pokemon species: {}", args.pokemon),
       ));
     },
   };
@@ -48,8 +45,8 @@ pub async fn print_eggs(
   // Get egg group names
   let mut egg_names = Vec::new();
   for egg in eggs.iter() {
-    egg_names.push(if !fast {
-      get_name!(egg, client, lang.to_string())
+    egg_names.push(if !args.fast {
+      get_name!(egg, client, args.lang.to_string())
     } else {
       egg.name.clone()
     });
@@ -59,8 +56,8 @@ pub async fn print_eggs(
   let mut result = Vec::new();
   result.push(format!(
     "{}:",
-    if !fast {
-      get_name!(species, client, lang.to_string())
+    if !args.fast {
+      get_name!(species, client, args.lang.to_string())
     } else {
       species.name.clone()
     }
@@ -75,6 +72,7 @@ pub async fn print_eggs(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::LanguageId;
 
   #[tokio::test]
   async fn test_eggs() {
@@ -86,11 +84,13 @@ mod tests {
     ];
 
     for (idx, vals) in success.into_iter().enumerate() {
-      let pokemon = String::from("stantler");
-      let fast = idx == 0;
-      let lang = LanguageId::En;
+      let args = EggArgs {
+        pokemon: String::from("stantler"),
+        fast: idx == 0,
+        lang: LanguageId::En,
+      };
 
-      match print_eggs(&client, &pokemon, fast, lang).await {
+      match print_eggs(&client, args).await {
         Ok(res) => assert_eq!(res, vals),
         Err(err) => panic!("{}", err.render()),
       }

--- a/src/lookup/encounters.rs
+++ b/src/lookup/encounters.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::{LanguageId, Version};
+use crate::utils::cli::{self, EncounterArgs};
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;
@@ -9,23 +8,20 @@ use rustemon::model::encounters::EncounterMethod;
 
 pub async fn print_encounters(
   client: &RustemonClient,
-  version: Version,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
-  recursive: bool,
-  condensed: bool,
+  args: EncounterArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon resources
-  let resources = match helpers::get_pokemon_from_chain(client, pokemon, recursive).await {
+  let resources = match helpers::get_pokemon_from_chain(client, &args.pokemon, args.recursive).await
+  {
     Ok(x) => x,
     Err(_) => {
       let valid = cli::VALID;
       let err = cli::error(
         ErrorKind::InvalidValue,
         format!(
-          "invalid pokemon: {pokemon}\n\n{valid}tip:{valid:#} try running '{} list {pokemon}'",
-          cli::get_appname()
+          "invalid pokemon: {1}\n\n{valid}tip:{valid:#} try running '{} list {}'",
+          cli::get_appname(),
+          args.pokemon,
         ),
       );
       return Err(err);
@@ -53,13 +49,13 @@ pub async fn print_encounters(
     let mut encounter_names = Vec::new();
     for enc in encounters.iter() {
       for det in enc.version_details.iter() {
-        if det.version.name == version.to_string() {
-          let name = if !fast {
-            get_name!(follow enc.location_area, client, lang.to_string())
+        if det.version.name == args.version.to_string() {
+          let name = if !args.fast {
+            get_name!(follow enc.location_area, client, args.lang.to_string())
           } else {
             enc.location_area.name.clone()
           };
-          if condensed {
+          if args.condensed {
             encounter_names.push(name);
           } else {
             let mut temp_details = Vec::new();
@@ -79,8 +75,8 @@ pub async fn print_encounters(
             for method in encounter_methods.iter() {
               temp_details.push(format!(
                 "   * {}",
-                if !fast {
-                  get_name!(method, client, lang.to_string())
+                if !args.fast {
+                  get_name!(method, client, args.lang.to_string())
                 } else {
                   method.name.clone()
                 }
@@ -104,8 +100,8 @@ pub async fn print_encounters(
     // Return location areas
     result.push(format!(
       "{}:",
-      if !fast {
-        helpers::get_pokemon_name(client, mon_resource, &lang.to_string()).await
+      if !args.fast {
+        helpers::get_pokemon_name(client, mon_resource, &args.lang.to_string()).await
       } else {
         mon_resource.name.clone()
       }
@@ -121,6 +117,7 @@ pub async fn print_encounters(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::{LanguageId, Version};
 
   #[tokio::test]
   async fn test_encounters() {
@@ -154,14 +151,16 @@ mod tests {
     ];
 
     for (idx, vals) in success.into_iter().enumerate() {
-      let version = Version::Firered;
-      let pokemon = String::from("machop");
-      let fast = idx == 0;
-      let lang = LanguageId::En;
-      let recursive = false;
-      let condensed = true;
+      let args = EncounterArgs {
+        version: Version::Firered,
+        pokemon: String::from("machop"),
+        fast: idx == 0,
+        lang: LanguageId::En,
+        recursive: false,
+        condensed: true,
+      };
 
-      match print_encounters(&client, version, &pokemon, fast, lang, recursive, condensed).await {
+      match print_encounters(&client, args).await {
         Ok(res) => assert_eq!(res, vals),
         Err(err) => panic!("{}", err.render()),
       }
@@ -200,14 +199,16 @@ mod tests {
       " - berry-forest-area",
     ];
 
-    let version = Version::Firered;
-    let pokemon = String::from("goldeen");
-    let fast = true;
-    let lang = LanguageId::En;
-    let recursive = true;
-    let condensed = true;
+    let args = EncounterArgs {
+      version: Version::Firered,
+      pokemon: String::from("goldeen"),
+      fast: true,
+      lang: LanguageId::En,
+      recursive: true,
+      condensed: true,
+    };
 
-    match print_encounters(&client, version, &pokemon, fast, lang, recursive, condensed).await {
+    match print_encounters(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }
@@ -238,14 +239,16 @@ mod tests {
       " - stony-wilderness-max-den-a\n   * max-raid",
     ];
 
-    let version = Version::Sword;
-    let pokemon = String::from("skwovet");
-    let fast = true;
-    let lang = LanguageId::En;
-    let recursive = false;
-    let condensed = false;
+    let args = EncounterArgs {
+      version: Version::Sword,
+      pokemon: String::from("skwovet"),
+      fast: true,
+      lang: LanguageId::En,
+      recursive: false,
+      condensed: false,
+    };
 
-    match print_encounters(&client, version, &pokemon, fast, lang, recursive, condensed).await {
+    match print_encounters(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/lookup/encounters.rs
+++ b/src/lookup/encounters.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, EncounterArgs};
+use crate::utils::args::EncounterArgs;
+use crate::utils::cli;
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;

--- a/src/lookup/evolutions.rs
+++ b/src/lookup/evolutions.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::LanguageId;
+use crate::utils::cli::{self, EvolutionArgs};
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;
@@ -9,19 +8,15 @@ use rustemon::pokemon::*;
 
 pub async fn print_evolutions(
   client: &RustemonClient,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
-  secret: bool,
-  all: bool,
+  args: EvolutionArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon species resource
-  let species = match pokemon_species::get_by_name(&pokemon.replace(" ", "-"), client).await {
+  let species = match pokemon_species::get_by_name(&args.pokemon.replace(" ", "-"), client).await {
     Ok(x) => x,
     Err(_) => {
       return Err(cli::error(
         ErrorKind::InvalidValue,
-        format!("invalid pokemon species: {pokemon}"),
+        format!("invalid pokemon species: {}", args.pokemon),
       ));
     },
   };
@@ -49,9 +44,9 @@ pub async fn print_evolutions(
         helpers::get_evolution_name(
           client,
           &chain.chain.species,
-          &lang.to_string(),
-          fast,
-          secret,
+          &args.lang.to_string(),
+          args.fast,
+          args.secret,
         )
         .await,
       );
@@ -65,16 +60,23 @@ pub async fn print_evolutions(
           helpers::get_evolution_name(
             client,
             &chain.chain.species,
-            &lang.to_string(),
-            fast,
-            secret,
+            &args.lang.to_string(),
+            args.fast,
+            args.secret,
           )
           .await,
-          helpers::get_evolution_name(client, &evo1.species, &lang.to_string(), fast, secret).await,
+          helpers::get_evolution_name(
+            client,
+            &evo1.species,
+            &args.lang.to_string(),
+            args.fast,
+            args.secret
+          )
+          .await,
         ));
       } else {
         for details1 in evo1.evolution_details.iter() {
-          if !all && !details1.is_default {
+          if !args.all && !details1.is_default {
             continue;
           }
 
@@ -82,27 +84,31 @@ pub async fn print_evolutions(
             "{} -> {}",
             if let Some(base_form_resource) = &details1.base_form {
               let base_form = base_form_resource.follow(client).await.unwrap();
-              helpers::get_pokemon_name(client, &base_form, &lang.to_string()).await
+              helpers::get_pokemon_name(client, &base_form, &args.lang.to_string()).await
             } else {
               helpers::get_evolution_name(
                 client,
                 &chain.chain.species,
-                &lang.to_string(),
-                fast,
-                secret,
+                &args.lang.to_string(),
+                args.fast,
+                args.secret,
               )
               .await
             },
-            if !fast {
-              get_name!(follow details1.trigger, client, lang.to_string())
+            if !args.fast {
+              get_name!(follow details1.trigger, client, args.lang.to_string())
             } else {
               details1.trigger.name.clone()
             },
           ));
 
-          if let Some(details_str) =
-            helpers::get_evolution_details(client, details1, &lang.to_string(), fast || secret)
-              .await
+          if let Some(details_str) = helpers::get_evolution_details(
+            client,
+            details1,
+            &args.lang.to_string(),
+            args.fast || args.secret,
+          )
+          .await
           {
             result
               .last_mut()
@@ -114,10 +120,16 @@ pub async fn print_evolutions(
             " -> {}",
             if let Some(evolved_form_resource) = &details1.evolved_form {
               let evolved_form = evolved_form_resource.follow(client).await.unwrap();
-              helpers::get_pokemon_name(client, &evolved_form, &lang.to_string()).await
+              helpers::get_pokemon_name(client, &evolved_form, &args.lang.to_string()).await
             } else {
-              helpers::get_evolution_name(client, &evo1.species, &lang.to_string(), fast, secret)
-                .await
+              helpers::get_evolution_name(
+                client,
+                &evo1.species,
+                &args.lang.to_string(),
+                args.fast,
+                args.secret,
+              )
+              .await
             }
           ));
 
@@ -126,20 +138,21 @@ pub async fn print_evolutions(
           let curr_steps = result.last().unwrap().clone();
           for evo2 in evo1.evolves_to.iter() {
             for details2 in evo2.evolution_details.iter() {
-              if !all && !details2.is_default {
+              if !args.all && !details2.is_default {
                 continue;
               }
               let mut temp_steps: String = format!(
                 " -> {}",
-                if !fast {
-                  get_name!(follow details2.trigger, client, lang.to_string())
+                if !args.fast {
+                  get_name!(follow details2.trigger, client, args.lang.to_string())
                 } else {
                   details2.trigger.name.clone()
                 }
               );
 
               if let Some(details_str) =
-                helpers::get_evolution_details(client, details2, &lang.to_string(), fast).await
+                helpers::get_evolution_details(client, details2, &args.lang.to_string(), args.fast)
+                  .await
               {
                 temp_steps.push_str(&format!(" ({details_str})"));
               }
@@ -148,14 +161,14 @@ pub async fn print_evolutions(
                 " -> {}",
                 if let Some(evolved_form_resource) = &details2.evolved_form {
                   let evolved_form = evolved_form_resource.follow(client).await.unwrap();
-                  helpers::get_pokemon_name(client, &evolved_form, &lang.to_string()).await
+                  helpers::get_pokemon_name(client, &evolved_form, &args.lang.to_string()).await
                 } else {
                   helpers::get_evolution_name(
                     client,
                     &evo2.species,
-                    &lang.to_string(),
-                    fast,
-                    secret,
+                    &args.lang.to_string(),
+                    args.fast,
+                    args.secret,
                   )
                   .await
                 }
@@ -174,12 +187,12 @@ pub async fn print_evolutions(
     }
   } else {
     // No chain found => record species name to final result
-    result.push(if secret {
+    result.push(if args.secret {
       String::from("???")
-    } else if fast {
+    } else if args.fast {
       species.name.clone()
     } else {
-      get_name!(species, client, lang.to_string())
+      get_name!(species, client, args.lang.to_string())
     });
   }
 
@@ -189,6 +202,7 @@ pub async fn print_evolutions(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::LanguageId;
 
   #[tokio::test]
   async fn test_evolutions() {
@@ -240,13 +254,15 @@ mod tests {
     ];
 
     for (idx, vals) in success.into_iter().enumerate() {
-      let pokemon = String::from("Eevee");
-      let fast = idx == 0;
-      let lang = LanguageId::En;
-      let secret = false;
-      let all = true;
+      let args = EvolutionArgs {
+        pokemon: String::from("eevee"),
+        fast: idx == 0,
+        lang: LanguageId::En,
+        secret: false,
+        all: true,
+      };
 
-      match print_evolutions(&client, &pokemon, fast, lang, secret, all).await {
+      match print_evolutions(&client, args).await {
         Ok(res) => assert_eq!(res, vals),
         Err(err) => panic!("{}", err.render()),
       }
@@ -279,13 +295,15 @@ mod tests {
       "MON -> level-up (known_move_type: fairy, min_happiness: 160) -> MON",
     ];
 
-    let pokemon = String::from("Eevee");
-    let fast = true;
-    let lang = LanguageId::En;
-    let secret = true;
-    let all = true;
+    let args = EvolutionArgs {
+      pokemon: String::from("eevee"),
+      fast: true,
+      lang: LanguageId::En,
+      secret: true,
+      all: true,
+    };
 
-    match print_evolutions(&client, &pokemon, fast, lang, secret, all).await {
+    match print_evolutions(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }
@@ -317,13 +335,15 @@ mod tests {
       "Eevee -> level-up (known_move_type: Hada, min_happiness: 160) -> Sylveon",
     ];
 
-    let pokemon = String::from("Eevee");
-    let fast = false;
-    let lang = LanguageId::Es;
-    let secret = false;
-    let all = true;
+    let args = EvolutionArgs {
+      pokemon: String::from("eevee"),
+      fast: false,
+      lang: LanguageId::Es,
+      secret: false,
+      all: true,
+    };
 
-    match print_evolutions(&client, &pokemon, fast, lang, secret, all).await {
+    match print_evolutions(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }
@@ -344,13 +364,15 @@ mod tests {
       "Eevee -> Level up (known_move_type: Fairy, min_happiness: 160) -> Sylveon",
     ];
 
-    let pokemon = String::from("Eevee");
-    let fast = false;
-    let lang = LanguageId::En;
-    let secret = false;
-    let all = false;
+    let args = EvolutionArgs {
+      pokemon: String::from("eevee"),
+      fast: false,
+      lang: LanguageId::En,
+      secret: false,
+      all: false,
+    };
 
-    match print_evolutions(&client, &pokemon, fast, lang, secret, all).await {
+    match print_evolutions(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }
@@ -365,13 +387,15 @@ mod tests {
       "Alolan Rattata -> Level up (min_level: 20, time_of_day: night) -> Alolan Raticate",
     ];
 
-    let pokemon = String::from("Rattata");
-    let fast = false;
-    let lang = LanguageId::En;
-    let secret = false;
-    let all = false;
+    let args = EvolutionArgs {
+      pokemon: String::from("rattata"),
+      fast: false,
+      lang: LanguageId::En,
+      secret: false,
+      all: false,
+    };
 
-    match print_evolutions(&client, &pokemon, fast, lang, secret, all).await {
+    match print_evolutions(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/lookup/evolutions.rs
+++ b/src/lookup/evolutions.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, EvolutionArgs};
+use crate::utils::args::EvolutionArgs;
+use crate::utils::cli;
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;

--- a/src/lookup/genders.rs
+++ b/src/lookup/genders.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::LanguageId;
+use crate::utils::cli::{self, GenderArgs};
 use clap::error::ErrorKind;
 use rustemon::Follow;
 use rustemon::client::RustemonClient;
@@ -8,17 +7,15 @@ use rustemon::pokemon::*;
 
 pub async fn print_genders(
   client: &RustemonClient,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
+  args: GenderArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon species resource
-  let species = match pokemon_species::get_by_name(&pokemon.replace(" ", "-"), client).await {
+  let species = match pokemon_species::get_by_name(&args.pokemon.replace(" ", "-"), client).await {
     Ok(x) => x,
     Err(_) => {
       return Err(cli::error(
         ErrorKind::InvalidValue,
-        format!("invalid pokemon species: {pokemon}"),
+        format!("invalid pokemon species: {}", args.pokemon),
       ));
     },
   };
@@ -27,8 +24,8 @@ pub async fn print_genders(
   let mut result = Vec::new();
   result.push(format!(
     "{}:",
-    if !fast {
-      get_name!(species, client, lang.to_string())
+    if !args.fast {
+      get_name!(species, client, args.lang.to_string())
     } else {
       species.name.clone()
     }
@@ -47,16 +44,20 @@ pub async fn print_genders(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::LanguageId;
 
   #[tokio::test]
   async fn test_genders() {
     let client = RustemonClient::default();
 
     for fast in vec![false, true].into_iter() {
-      let pokemon = String::from("meowth");
-      let lang = LanguageId::En;
+      let args = GenderArgs {
+        pokemon: String::from("meowth"),
+        fast,
+        lang: LanguageId::En,
+      };
 
-      match print_genders(&client, &pokemon, fast, lang).await {
+      match print_genders(&client, args).await {
         Ok(s) => assert_eq!(
           s,
           vec![

--- a/src/lookup/genders.rs
+++ b/src/lookup/genders.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, GenderArgs};
+use crate::utils::args::GenderArgs;
+use crate::utils::cli;
 use clap::error::ErrorKind;
 use rustemon::Follow;
 use rustemon::client::RustemonClient;

--- a/src/lookup/matchups.rs
+++ b/src/lookup/matchups.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::{LanguageId, Type};
+use crate::utils::cli::{self, MatchupArgs};
 use clap::error::ErrorKind;
 use itertools::izip;
 use rustemon::Follow;
@@ -9,23 +8,19 @@ use rustemon::pokemon::*;
 
 pub async fn print_matchups(
   client: &RustemonClient,
-  primary: Type,
-  secondary: Option<Type>,
-  list: bool,
-  fast: bool,
-  lang: LanguageId,
+  args: MatchupArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Get type resources
-  let primary = match type_::get_by_name(&primary.to_string(), client).await {
+  let primary = match type_::get_by_name(&args.primary.to_string(), client).await {
     Ok(x) => x,
     Err(_) => {
       return Err(cli::error(
         ErrorKind::InvalidValue,
-        format!("API error: could not retrieve type {primary}"),
+        format!("API error: could not retrieve type {}", args.primary),
       ));
     },
   };
-  let secondary = match secondary {
+  let secondary = match args.secondary {
     Some(t) => match type_::get_by_name(&t.to_string(), client).await {
       Ok(x) => Some(x),
       Err(_) => {
@@ -46,30 +41,30 @@ pub async fn print_matchups(
   let mut quad_damage_from = Vec::new();
 
   for other_type in primary.damage_relations.no_damage_from.iter() {
-    no_damage_from.push(if !fast {
-      get_name!(follow other_type, client, lang.to_string())
+    no_damage_from.push(if !args.fast {
+      get_name!(follow other_type, client, args.lang.to_string())
     } else {
       other_type.name.clone()
     });
   }
   for other_type in primary.damage_relations.half_damage_from.iter() {
-    half_damage_from.push(if !fast {
-      get_name!(follow other_type, client, lang.to_string())
+    half_damage_from.push(if !args.fast {
+      get_name!(follow other_type, client, args.lang.to_string())
     } else {
       other_type.name.clone()
     });
   }
   for other_type in primary.damage_relations.double_damage_from.iter() {
-    double_damage_from.push(if !fast {
-      get_name!(follow other_type, client, lang.to_string())
+    double_damage_from.push(if !args.fast {
+      get_name!(follow other_type, client, args.lang.to_string())
     } else {
       other_type.name.clone()
     });
   }
   if let Some(ref second) = secondary {
     for other_type in second.damage_relations.no_damage_from.iter() {
-      let name = if !fast {
-        get_name!(follow other_type, client, lang.to_string())
+      let name = if !args.fast {
+        get_name!(follow other_type, client, args.lang.to_string())
       } else {
         other_type.name.clone()
       };
@@ -84,8 +79,8 @@ pub async fn print_matchups(
       }
     }
     for other_type in second.damage_relations.half_damage_from.iter() {
-      let name = if !fast {
-        get_name!(follow other_type, client, lang.to_string())
+      let name = if !args.fast {
+        get_name!(follow other_type, client, args.lang.to_string())
       } else {
         other_type.name.clone()
       };
@@ -99,8 +94,8 @@ pub async fn print_matchups(
       }
     }
     for other_type in second.damage_relations.double_damage_from.iter() {
-      let name = if !fast {
-        get_name!(follow other_type, client, lang.to_string())
+      let name = if !args.fast {
+        get_name!(follow other_type, client, args.lang.to_string())
       } else {
         other_type.name.clone()
       };
@@ -142,7 +137,7 @@ pub async fn print_matchups(
   let mut result = Vec::new();
   match secondary {
     None => {
-      if !list {
+      if !args.list {
         result.push(format!("{:^12} {:^12} {:^12}", "*0", "*0.5", "*2"));
         result.push(format!("{:-<12} {:-<12} {:-<12}", "", "", ""));
         for (no_dmg, half_dmg, double_dmg) in
@@ -153,8 +148,8 @@ pub async fn print_matchups(
       } else {
         result.push(format!(
           "{}:",
-          if !fast {
-            get_name!(primary, client, lang.to_string())
+          if !args.fast {
+            get_name!(primary, client, args.lang.to_string())
           } else {
             primary.name.clone()
           },
@@ -198,7 +193,7 @@ pub async fn print_matchups(
       }
     },
     Some(second) => {
-      if !list {
+      if !args.list {
         result.push(format!(
           "{:^12} {:^12} {:^12} {:^12} {:^12}",
           "*0", "*0.25", "*0.5", "*2", "*4"
@@ -219,13 +214,13 @@ pub async fn print_matchups(
         result.push(format!(
           "{}:",
           [
-            if !fast {
-              get_name!(primary, client, lang.to_string())
+            if !args.fast {
+              get_name!(primary, client, args.lang.to_string())
             } else {
               primary.name.clone()
             },
-            if !fast {
-              get_name!(second, client, lang.to_string())
+            if !args.fast {
+              get_name!(second, client, args.lang.to_string())
             } else {
               second.name.clone()
             }
@@ -304,6 +299,7 @@ pub async fn print_matchups(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::{LanguageId, Type};
 
   #[tokio::test]
   async fn test_matchups() {
@@ -317,13 +313,15 @@ mod tests {
       "             Dark                     ",
     ];
 
-    let primary = Type::Fairy;
-    let secondary = None;
-    let fast = false;
-    let lang = LanguageId::En;
-    let list = false;
+    let args = MatchupArgs {
+      primary: Type::Fairy,
+      secondary: None,
+      list: false,
+      fast: false,
+      lang: LanguageId::En,
+    };
 
-    match print_matchups(&client, primary, secondary, list, fast, lang).await {
+    match print_matchups(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }
@@ -342,13 +340,15 @@ mod tests {
       "                          Rock         Ice                      ",
     ];
 
-    let primary = Type::Electric;
-    let secondary = Some(Type::Ground);
-    let fast = false;
-    let lang = LanguageId::En;
-    let list = false;
+    let args = MatchupArgs {
+      primary: Type::Electric,
+      secondary: Some(Type::Ground),
+      list: false,
+      fast: false,
+      lang: LanguageId::En,
+    };
 
-    match print_matchups(&client, primary, secondary, list, fast, lang).await {
+    match print_matchups(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }
@@ -364,13 +364,15 @@ mod tests {
       "   * Psíquico", "   * Hielo", "   * Hada", "", " - 2x:", "   * Tierra", "   * Fuego",
     ];
 
-    let primary = Type::Fairy;
-    let secondary = Some(Type::Steel);
-    let fast = false;
-    let lang = LanguageId::Es;
-    let list = true;
+    let args = MatchupArgs {
+      primary: Type::Fairy,
+      secondary: Some(Type::Steel),
+      list: true,
+      fast: false,
+      lang: LanguageId::Es,
+    };
 
-    match print_matchups(&client, primary, secondary, list, fast, lang).await {
+    match print_matchups(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/lookup/matchups.rs
+++ b/src/lookup/matchups.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, MatchupArgs};
+use crate::utils::args::MatchupArgs;
+use crate::utils::cli;
 use clap::error::ErrorKind;
 use itertools::izip;
 use rustemon::Follow;

--- a/src/lookup/moves.rs
+++ b/src/lookup/moves.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::{LanguageId, VersionGroup};
+use crate::utils::cli::{self, MoveArgs};
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;
@@ -9,22 +8,19 @@ use rustemon::pokemon::*;
 
 pub async fn print_moves(
   client: &RustemonClient,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
-  vgroup: VersionGroup,
-  level: Option<i64>,
+  args: MoveArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon resource
-  let mon_resource = match pokemon::get_by_name(&pokemon.replace(" ", "-"), client).await {
+  let mon_resource = match pokemon::get_by_name(&args.pokemon.replace(" ", "-"), client).await {
     Ok(x) => x,
     Err(_) => {
       let valid = cli::VALID;
       let err = cli::error(
         ErrorKind::InvalidValue,
         format!(
-          "invalid pokemon: {pokemon}\n\n{valid}tip:{valid:#} try running '{} list {pokemon}'",
-          cli::get_appname()
+          "invalid pokemon: {1}\n\n{valid}tip:{valid:#} try running '{} list {}'",
+          cli::get_appname(),
+          args.pokemon,
         ),
       );
       return Err(err);
@@ -42,14 +38,14 @@ pub async fn print_moves(
   for move_resource in mon_resource.moves.iter() {
     for details in move_resource.version_group_details.iter() {
       if details.move_learn_method.name == "level-up"
-        && details.version_group.name == vgroup.to_string()
+        && details.version_group.name == args.vgroup.to_string()
       {
-        match level {
+        match args.level {
           Some(x) if details.level_learned_at > x => {},
           _ => {
             moves.push(Move {
-              name: if !fast {
-                get_name!(follow move_resource.move_, client, lang.to_string())
+              name: if !args.fast {
+                get_name!(follow move_resource.move_, client, args.lang.to_string())
               } else {
                 move_resource.move_.name.clone()
               },
@@ -65,7 +61,7 @@ pub async fn print_moves(
   moves.sort_by_key(|m| std::cmp::Reverse(m.level));
 
   // Get current moveset (if requested)
-  let mut moves = if level.is_some() {
+  let mut moves = if args.level.is_some() {
     moves.iter().take(4).collect::<Vec<_>>()
   } else {
     moves.iter().collect::<Vec<_>>()
@@ -76,8 +72,8 @@ pub async fn print_moves(
   let mut result = Vec::new();
   result.push(format!(
     "{}:",
-    if !fast {
-      helpers::get_pokemon_name(client, &mon_resource, &lang.to_string()).await
+    if !args.fast {
+      helpers::get_pokemon_name(client, &mon_resource, &args.lang.to_string()).await
     } else {
       mon_resource.name.clone()
     }
@@ -92,6 +88,7 @@ pub async fn print_moves(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::{LanguageId, VersionGroup};
 
   #[tokio::test]
   async fn test_moves() {
@@ -111,13 +108,15 @@ mod tests {
     ];
 
     for (idx, vals) in success.into_iter().enumerate() {
-      let pokemon = String::from("quaxly");
-      let fast = idx == 0;
-      let lang = LanguageId::En;
-      let vgroup = VersionGroup::ScarletViolet;
-      let level = None;
+      let args = MoveArgs {
+        pokemon: String::from("quaxly"),
+        fast: idx == 0,
+        lang: LanguageId::En,
+        vgroup: VersionGroup::ScarletViolet,
+        level: None,
+      };
 
-      match print_moves(&client, &pokemon, fast, lang, vgroup, level).await {
+      match print_moves(&client, args).await {
         Ok(res) => assert_eq!(res, vals),
         Err(err) => panic!("{}", err.render()),
       }
@@ -133,13 +132,15 @@ mod tests {
       " - Focus Energy (28)",
     ];
 
-    let pokemon = String::from("quaxly");
-    let level = Some(30);
-    let fast = false;
-    let vgroup = VersionGroup::ScarletViolet;
-    let lang = LanguageId::En;
+    let args = MoveArgs {
+      pokemon: String::from("quaxly"),
+      fast: false,
+      lang: LanguageId::En,
+      vgroup: VersionGroup::ScarletViolet,
+      level: Some(30),
+    };
 
-    match print_moves(&client, &pokemon, fast, lang, vgroup, level).await {
+    match print_moves(&client, args).await {
       Ok(res) => assert_eq!(res, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/lookup/moves.rs
+++ b/src/lookup/moves.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, MoveArgs};
+use crate::utils::args::MoveArgs;
+use crate::utils::cli;
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;

--- a/src/lookup/types.rs
+++ b/src/lookup/types.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::LanguageId;
+use crate::utils::cli::{self, TypeArgs};
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;
@@ -8,22 +7,20 @@ use rustemon::client::RustemonClient;
 
 pub async fn print_types(
   client: &RustemonClient,
-  pokemon: &str,
-  generation: Option<i64>,
-  fast: bool,
-  lang: LanguageId,
-  recursive: bool,
+  args: TypeArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon resources
-  let resources = match helpers::get_pokemon_from_chain(client, pokemon, recursive).await {
+  let resources = match helpers::get_pokemon_from_chain(client, &args.pokemon, args.recursive).await
+  {
     Ok(x) => x,
     Err(_) => {
       let valid = cli::VALID;
       let err = cli::error(
         ErrorKind::InvalidValue,
         format!(
-          "invalid pokemon: {pokemon}\n\n{valid}tip:{valid:#} try running '{} list {pokemon}'",
-          cli::get_appname()
+          "invalid pokemon: {1}\n\n{valid}tip:{valid:#} try running '{} list {}'",
+          cli::get_appname(),
+          args.pokemon,
         ),
       );
       return Err(err);
@@ -36,21 +33,21 @@ pub async fn print_types(
     // Get type names
     let mut type_names = Vec::new();
     for item in mon_resource.types.iter() {
-      type_names.push(if !fast {
-        get_name!(follow item.type_, client, lang.to_string())
+      type_names.push(if !args.fast {
+        get_name!(follow item.type_, client, args.lang.to_string())
       } else {
         item.type_.name.clone()
       });
     }
-    if let Some(generation) = generation {
+    if let Some(generation) = args.generation {
       for past_item in mon_resource.past_types.iter() {
         if let Ok(x) = past_item.generation.follow(client).await
           && x.id >= generation
         {
           type_names.clear();
           for item in past_item.types.iter() {
-            type_names.push(if !fast {
-              get_name!(follow item.type_, client, lang.to_string())
+            type_names.push(if !args.fast {
+              get_name!(follow item.type_, client, args.lang.to_string())
             } else {
               item.type_.name.clone()
             });
@@ -62,8 +59,8 @@ pub async fn print_types(
     // Return types
     result.push(format!(
       "{}:",
-      if !fast {
-        helpers::get_pokemon_name(client, mon_resource, &lang.to_string()).await
+      if !args.fast {
+        helpers::get_pokemon_name(client, mon_resource, &args.lang.to_string()).await
       } else {
         mon_resource.name.clone()
       }
@@ -77,6 +74,7 @@ pub async fn print_types(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::LanguageId;
 
   #[tokio::test]
   async fn test_types() {
@@ -88,12 +86,15 @@ mod tests {
       .collect();
 
     for fast in [false, true].into_iter() {
-      let pokemon = String::from("toxel");
-      let generation = None;
-      let lang = LanguageId::En;
-      let recursive = false;
+      let args = TypeArgs {
+        pokemon: String::from("toxel"),
+        fast,
+        generation: None,
+        lang: LanguageId::En,
+        recursive: false,
+      };
 
-      match print_types(&client, &pokemon, generation, fast, lang, recursive).await {
+      match print_types(&client, args).await {
         Ok(s) => assert_eq!(
           s,
           if fast {
@@ -117,20 +118,21 @@ mod tests {
       .collect();
 
     for generation in 1..=5 {
-      let pokemon = String::from("jigglypuff");
-      let generation = Some(generation);
-      let fast = true;
-      let lang = LanguageId::En;
-      let recursive = false;
+      let args = TypeArgs {
+        pokemon: String::from("jigglypuff"),
+        fast: true,
+        generation: Some(generation),
+        lang: LanguageId::En,
+        recursive: false,
+      };
 
-      match print_types(&client, &pokemon, generation, fast, lang, recursive).await {
+      match print_types(&client, args).await {
         Ok(s) => assert_eq!(
           s,
-          if fast {
-            success.iter().map(|x| x.to_lowercase()).collect()
-          } else {
-            success.clone()
-          }
+          success
+            .iter()
+            .map(|x| x.to_lowercase())
+            .collect::<Vec<String>>()
         ),
         Err(err) => panic!("{}", err.render()),
       }
@@ -142,13 +144,15 @@ mod tests {
     let client = RustemonClient::default();
 
     let success = vec!["stantler:", "  normal", "wyrdeer:", "  normal/psychic"];
-    let pokemon = String::from("stantler");
-    let generation = None;
-    let fast = true;
-    let lang = LanguageId::En;
-    let recursive = true;
+    let args = TypeArgs {
+      pokemon: String::from("stantler"),
+      fast: true,
+      generation: None,
+      lang: LanguageId::En,
+      recursive: true,
+    };
 
-    match print_types(&client, &pokemon, generation, fast, lang, recursive).await {
+    match print_types(&client, args).await {
       Ok(s) => assert_eq!(s, success),
       Err(err) => panic!("{}", err.render()),
     }

--- a/src/lookup/types.rs
+++ b/src/lookup/types.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, TypeArgs};
+use crate::utils::args::TypeArgs;
+use crate::utils::cli;
 use crate::utils::helpers;
 use clap::error::ErrorKind;
 use rustemon::Follow;

--- a/src/lookup/varieties.rs
+++ b/src/lookup/varieties.rs
@@ -1,5 +1,6 @@
 use crate::get_name;
-use crate::utils::cli::{self, ListArgs};
+use crate::utils::args::ListArgs;
+use crate::utils::cli;
 use clap::error::ErrorKind;
 use rustemon::Follow;
 use rustemon::client::RustemonClient;

--- a/src/lookup/varieties.rs
+++ b/src/lookup/varieties.rs
@@ -1,6 +1,5 @@
 use crate::get_name;
-use crate::utils::cli;
-use crate::utils::enums::LanguageId;
+use crate::utils::cli::{self, ListArgs};
 use clap::error::ErrorKind;
 use rustemon::Follow;
 use rustemon::client::RustemonClient;
@@ -8,17 +7,15 @@ use rustemon::pokemon::*;
 
 pub async fn print_varieties(
   client: &RustemonClient,
-  pokemon: &str,
-  fast: bool,
-  lang: LanguageId,
+  args: ListArgs,
 ) -> Result<Vec<String>, clap::Error> {
   // Create pokemon species resource
-  let species = match pokemon_species::get_by_name(&pokemon.replace(' ', "-"), client).await {
+  let species = match pokemon_species::get_by_name(&args.pokemon.replace(' ', "-"), client).await {
     Ok(x) => x,
     Err(_) => {
       return Err(cli::error(
         ErrorKind::InvalidValue,
-        format!("invalid pokemon species: {pokemon}"),
+        format!("invalid pokemon species: {}", args.pokemon),
       ));
     },
   };
@@ -27,8 +24,8 @@ pub async fn print_varieties(
   let mut result = Vec::new();
   result.push(format!(
     "{}:",
-    if !fast {
-      get_name!(species, client, lang.to_string())
+    if !args.fast {
+      get_name!(species, client, args.lang.to_string())
     } else {
       species.name.clone()
     }
@@ -44,16 +41,20 @@ pub async fn print_varieties(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils::enums::LanguageId;
 
   #[tokio::test]
   async fn test_varieties() {
     let client = RustemonClient::default();
 
     for fast in vec![false, true].into_iter() {
-      let pokemon = String::from("meowth");
-      let lang = LanguageId::En;
+      let args = ListArgs {
+        pokemon: String::from("meowth"),
+        fast,
+        lang: LanguageId::En,
+      };
 
-      match print_varieties(&client, &pokemon, fast, lang).await {
+      match print_varieties(&client, args).await {
         Ok(s) => {
           assert_eq!(
             s,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,13 +44,7 @@ async fn main() {
   // Call the appropriate subcommand for results
   let result = match args.command {
     Command::ListCmd(args) => lookup::print_varieties(&client, args).await,
-    Command::TypeCmd {
-      pokemon,
-      fast,
-      generation,
-      lang,
-      recursive,
-    } => lookup::print_types(&client, &pokemon, generation, fast, lang, recursive).await,
+    Command::TypeCmd(args) => lookup::print_types(&client, args).await,
     Command::AbilityCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,11 +47,7 @@ async fn main() {
     Command::TypeCmd(args) => lookup::print_types(&client, args).await,
     Command::AbilityCmd(args) => lookup::print_abilities(&client, args).await,
     Command::MoveCmd(args) => lookup::print_moves(&client, args).await,
-    Command::EggCmd {
-      pokemon,
-      fast,
-      lang,
-    } => lookup::print_eggs(&client, &pokemon, fast, lang).await,
+    Command::EggCmd(args) => lookup::print_eggs(&client, args).await,
     Command::GenderCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,11 +43,7 @@ async fn main() {
 
   // Call the appropriate subcommand for results
   let result = match args.command {
-    Command::ListCmd {
-      pokemon,
-      fast,
-      lang,
-    } => lookup::print_varieties(&client, &pokemon, fast, lang).await,
+    Command::ListCmd(args) => lookup::print_varieties(&client, args).await,
     Command::TypeCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,13 +46,7 @@ async fn main() {
     Command::ListCmd(args) => lookup::print_varieties(&client, args).await,
     Command::TypeCmd(args) => lookup::print_types(&client, args).await,
     Command::AbilityCmd(args) => lookup::print_abilities(&client, args).await,
-    Command::MoveCmd {
-      pokemon,
-      fast,
-      lang,
-      vgroup,
-      level,
-    } => lookup::print_moves(&client, &pokemon, fast, lang, vgroup, level).await,
+    Command::MoveCmd(args) => lookup::print_moves(&client, args).await,
     Command::EggCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use utils::cli::{Cli, Command, get_appname};
 #[cfg(feature = "web")]
 use clap::error::ErrorKind;
 #[cfg(feature = "web")]
-use utils::{cli, cli::DexMode};
+use utils::{args::DexMode, cli};
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,13 +50,7 @@ async fn main() {
     Command::EggCmd(args) => lookup::print_eggs(&client, args).await,
     Command::GenderCmd(args) => lookup::print_genders(&client, args).await,
     Command::EncounterCmd(args) => lookup::print_encounters(&client, args).await,
-    Command::EvolutionCmd {
-      pokemon,
-      fast,
-      lang,
-      secret,
-      all,
-    } => lookup::print_evolutions(&client, &pokemon, fast, lang, secret, all).await,
+    Command::EvolutionCmd(args) => lookup::print_evolutions(&client, args).await,
     Command::MatchupCmd {
       primary,
       secondary,

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,13 +51,7 @@ async fn main() {
     Command::GenderCmd(args) => lookup::print_genders(&client, args).await,
     Command::EncounterCmd(args) => lookup::print_encounters(&client, args).await,
     Command::EvolutionCmd(args) => lookup::print_evolutions(&client, args).await,
-    Command::MatchupCmd {
-      primary,
-      secondary,
-      list,
-      fast,
-      lang,
-    } => lookup::print_matchups(&client, primary, secondary, list, fast, lang).await,
+    Command::MatchupCmd(args) => lookup::print_matchups(&client, args).await,
     #[cfg(feature = "web")]
     Command::WebCmd {
       endpoint,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,12 +45,7 @@ async fn main() {
   let result = match args.command {
     Command::ListCmd(args) => lookup::print_varieties(&client, args).await,
     Command::TypeCmd(args) => lookup::print_types(&client, args).await,
-    Command::AbilityCmd {
-      pokemon,
-      fast,
-      lang,
-      recursive,
-    } => lookup::print_abilities(&client, &pokemon, fast, lang, recursive).await,
+    Command::AbilityCmd(args) => lookup::print_abilities(&client, args).await,
     Command::MoveCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,11 +48,7 @@ async fn main() {
     Command::AbilityCmd(args) => lookup::print_abilities(&client, args).await,
     Command::MoveCmd(args) => lookup::print_moves(&client, args).await,
     Command::EggCmd(args) => lookup::print_eggs(&client, args).await,
-    Command::GenderCmd {
-      pokemon,
-      fast,
-      lang,
-    } => lookup::print_genders(&client, &pokemon, fast, lang).await,
+    Command::GenderCmd(args) => lookup::print_genders(&client, args).await,
     Command::EncounterCmd {
       version,
       pokemon,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,16 +49,7 @@ async fn main() {
     Command::MoveCmd(args) => lookup::print_moves(&client, args).await,
     Command::EggCmd(args) => lookup::print_eggs(&client, args).await,
     Command::GenderCmd(args) => lookup::print_genders(&client, args).await,
-    Command::EncounterCmd {
-      version,
-      pokemon,
-      fast,
-      lang,
-      recursive,
-      condensed,
-    } => {
-      lookup::print_encounters(&client, version, &pokemon, fast, lang, recursive, condensed).await
-    },
+    Command::EncounterCmd(args) => lookup::print_encounters(&client, args).await,
     Command::EvolutionCmd {
       pokemon,
       fast,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod utils;
 use clap::Parser;
 use rustemon::client::RustemonClient;
 use std::{fs::create_dir, path::Path};
-use utils::cli::{Args, SubArgs, get_appname};
+use utils::cli::{Cli, Command, get_appname};
 
 #[cfg(feature = "web")]
 use clap::error::ErrorKind;
@@ -13,7 +13,7 @@ use utils::{cli, cli::DexMode};
 
 #[tokio::main]
 async fn main() {
-  let mut args = Args::parse();
+  let mut args = Cli::parse();
 
   // Create cache directory for API calls
   args.cache_dir = match args.cache_dir {
@@ -43,42 +43,42 @@ async fn main() {
 
   // Call the appropriate subcommand for results
   let result = match args.command {
-    SubArgs::ListCmd {
+    Command::ListCmd {
       pokemon,
       fast,
       lang,
     } => lookup::print_varieties(&client, &pokemon, fast, lang).await,
-    SubArgs::TypeCmd {
+    Command::TypeCmd {
       pokemon,
       fast,
       generation,
       lang,
       recursive,
     } => lookup::print_types(&client, &pokemon, generation, fast, lang, recursive).await,
-    SubArgs::AbilityCmd {
+    Command::AbilityCmd {
       pokemon,
       fast,
       lang,
       recursive,
     } => lookup::print_abilities(&client, &pokemon, fast, lang, recursive).await,
-    SubArgs::MoveCmd {
+    Command::MoveCmd {
       pokemon,
       fast,
       lang,
       vgroup,
       level,
     } => lookup::print_moves(&client, &pokemon, fast, lang, vgroup, level).await,
-    SubArgs::EggCmd {
+    Command::EggCmd {
       pokemon,
       fast,
       lang,
     } => lookup::print_eggs(&client, &pokemon, fast, lang).await,
-    SubArgs::GenderCmd {
+    Command::GenderCmd {
       pokemon,
       fast,
       lang,
     } => lookup::print_genders(&client, &pokemon, fast, lang).await,
-    SubArgs::EncounterCmd {
+    Command::EncounterCmd {
       version,
       pokemon,
       fast,
@@ -88,14 +88,14 @@ async fn main() {
     } => {
       lookup::print_encounters(&client, version, &pokemon, fast, lang, recursive, condensed).await
     },
-    SubArgs::EvolutionCmd {
+    Command::EvolutionCmd {
       pokemon,
       fast,
       lang,
       secret,
       all,
     } => lookup::print_evolutions(&client, &pokemon, fast, lang, secret, all).await,
-    SubArgs::MatchupCmd {
+    Command::MatchupCmd {
       primary,
       secondary,
       list,
@@ -103,7 +103,7 @@ async fn main() {
       lang,
     } => lookup::print_matchups(&client, primary, secondary, list, fast, lang).await,
     #[cfg(feature = "web")]
-    SubArgs::WebCmd {
+    Command::WebCmd {
       endpoint,
       generation,
       area,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,23 +53,18 @@ async fn main() {
     Command::EvolutionCmd(args) => lookup::print_evolutions(&client, args).await,
     Command::MatchupCmd(args) => lookup::print_matchups(&client, args).await,
     #[cfg(feature = "web")]
-    Command::WebCmd {
-      endpoint,
-      generation,
-      area,
-      quiet,
-    } => {
-      let url = match endpoint.get_mode() {
-        DexMode::Pokedex(name) => lookup::dex::open_pokedex(name, generation),
-        DexMode::Pokearth(name) => lookup::dex::open_pokearth(name, area, generation),
-        DexMode::Attackdex(name) => lookup::dex::open_attackdex(name, generation),
+    Command::WebCmd(args) => {
+      let url = match args.endpoint.get_mode() {
+        DexMode::Pokedex(name) => lookup::dex::open_pokedex(name, args.generation),
+        DexMode::Pokearth(name) => lookup::dex::open_pokearth(name, args.area, args.generation),
+        DexMode::Attackdex(name) => lookup::dex::open_attackdex(name, args.generation),
         DexMode::Abilitydex(name) => lookup::dex::open_abilitydex(name),
         DexMode::Itemdex(name) => lookup::dex::open_itemdex(name),
       };
       match url {
         Ok(url) => match open::that(&url) {
           Ok(_) => {
-            if quiet {
+            if args.quiet {
               return;
             }
             Ok(svec!["Opened page successfully."])

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+pub mod args;
 pub mod cli;
 pub mod enums;
 pub mod helpers;

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -1,0 +1,297 @@
+use crate::utils::enums::*;
+use clap::Args;
+
+// ========================================================================================================================
+// Subcommand Arguments
+// ========================================================================================================================
+
+#[derive(Args, Debug)]
+pub struct ListArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct TypeArgs {
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(short, long = "gen", help = "generation to query")]
+  pub generation: Option<i64>,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(short, help = "recursively check evolution chain")]
+  pub recursive: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct AbilityArgs {
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(short, help = "recursively check evolution chain")]
+  pub recursive: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct MoveArgs {
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(value_enum, short, long, default_value_t=VersionGroup::ScarletViolet,
+          hide_possible_values=true, help="version group name")]
+  pub vgroup: VersionGroup,
+
+  #[arg(short, long, help = "request default moveset at given level")]
+  pub level: Option<i64>,
+}
+
+#[derive(Args, Debug)]
+pub struct EggArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct GenderArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct EncounterArgs {
+  #[arg(value_enum, hide_possible_values = true, help = "name of version")]
+  pub version: Version,
+
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(short, help = "recursively check evolution chain")]
+  pub recursive: bool,
+
+  #[arg(short, long, help = "condense output by only showing location areas")]
+  pub condensed: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct EvolutionArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(
+    short,
+    long,
+    help = "hide the names of the pokemon in the evolution chain"
+  )]
+  pub secret: bool,
+
+  #[arg(short, long, help = "show all evolution chains, even outdated ones")]
+  pub all: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct MatchupArgs {
+  #[arg(
+    value_enum,
+    hide_possible_values = true,
+    value_name = "TYPE",
+    help = "name of type"
+  )]
+  pub primary: Type,
+
+  #[arg(
+    value_enum,
+    hide_possible_values = true,
+    value_name = "TYPE",
+    help = "name of optional secondary type"
+  )]
+  pub secondary: Option<Type>,
+
+  #[arg(short, long, help = "print output as a list instead of a table")]
+  pub list: bool,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct WebArgs {
+  #[command(flatten)]
+  pub endpoint: Endpoints,
+
+  #[arg(short = 'A', long, help = "name of area within region")]
+  pub area: Option<String>,
+
+  #[arg(short, long = "gen", help = "optional name of generation to use")]
+  pub generation: Option<i64>,
+
+  #[arg(short, long, help = "suppress print statements")]
+  pub quiet: bool,
+}
+
+#[cfg(feature = "web")]
+#[derive(Args, Debug)]
+#[group(required = true, multiple = false)]
+pub struct Endpoints {
+  #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area"], help = "name of pokemon")]
+  pub pokemon: Option<String>,
+
+  #[arg(short, long, help_heading = "Endpoints", help = "name of region")]
+  pub region: Option<String>,
+
+  #[arg(
+    short,
+    long,
+    help_heading = "Endpoints",
+    conflicts_with = "area",
+    help = "name of move"
+  )]
+  pub move_: Option<String>,
+
+  #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area", "generation"], help = "name of ability")]
+  pub ability: Option<String>,
+
+  #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area", "generation"], help = "name of item")]
+  pub item: Option<String>,
+}
+
+#[cfg(feature = "web")]
+impl Endpoints {
+  pub fn get_mode(&self) -> DexMode {
+    if let Some(name) = &self.pokemon {
+      DexMode::Pokedex(name.clone())
+    } else if let Some(name) = &self.region {
+      DexMode::Pokearth(name.clone())
+    } else if let Some(name) = &self.move_ {
+      DexMode::Attackdex(name.clone())
+    } else if let Some(name) = &self.ability {
+      DexMode::Abilitydex(name.clone())
+    } else if let Some(name) = &self.item {
+      DexMode::Itemdex(name.clone())
+    } else {
+      unreachable!()
+    }
+  }
+}
+
+#[cfg(feature = "web")]
+pub enum DexMode {
+  Pokedex(String),
+  Pokearth(String),
+  Attackdex(String),
+  Abilitydex(String),
+  Itemdex(String),
+}

--- a/src/utils/args.rs
+++ b/src/utils/args.rs
@@ -227,6 +227,7 @@ pub struct MatchupArgs {
   pub lang: LanguageId,
 }
 
+#[cfg(feature = "web")]
 #[derive(Args, Debug)]
 pub struct WebArgs {
   #[command(flatten)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,6 +1,6 @@
 use crate::utils::enums::*;
 use clap::builder::styling::{AnsiColor, Effects, Style, Styles};
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 
 pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
@@ -26,7 +26,7 @@ const CARGO_STYLING: Styles = Styles::styled()
 /// listed using the 'list' subcommand.
 #[derive(Parser, Debug)]
 #[command(version, long_about, styles=CARGO_STYLING)]
-pub struct Args {
+pub struct Cli {
   #[arg(
     long,
     value_name = "DIR",
@@ -35,11 +35,11 @@ pub struct Args {
   pub cache_dir: Option<std::path::PathBuf>,
 
   #[command(subcommand)]
-  pub command: SubArgs,
+  pub command: Command,
 }
 
 #[derive(Subcommand, Debug)]
-pub enum SubArgs {
+pub enum Command {
   /// Look up the varieties of a given pokemon.
   #[command(name = "list", long_about)]
   ListCmd {
@@ -301,7 +301,7 @@ pub enum SubArgs {
 }
 
 #[cfg(feature = "web")]
-#[derive(Debug, clap::Args)]
+#[derive(Args, Debug)]
 #[group(required = true, multiple = false)]
 pub struct Endpoints {
   #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area"], help = "name of pokemon")]
@@ -355,9 +355,9 @@ pub enum DexMode {
 }
 
 pub fn get_appname() -> String {
-  String::from(Args::command().get_name())
+  String::from(Cli::command().get_name())
 }
 
 pub fn error(kind: clap::error::ErrorKind, message: String) -> clap::Error {
-  Args::command().error(kind, message)
+  Cli::command().error(kind, message)
 }

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -85,39 +85,7 @@ pub enum Command {
 
   /// Look up the type weaknesses/resistances for given type(s).
   #[command(name = "matchups", long_about)]
-  MatchupCmd {
-    #[arg(
-      value_enum,
-      hide_possible_values = true,
-      value_name = "TYPE",
-      help = "name of type"
-    )]
-    primary: Type,
-
-    #[arg(
-      value_enum,
-      hide_possible_values = true,
-      value_name = "TYPE",
-      help = "name of optional secondary type"
-    )]
-    secondary: Option<Type>,
-
-    #[arg(short, long, help = "print output as a list instead of a table")]
-    list: bool,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-  },
+  MatchupCmd(MatchupArgs),
 
   /// Open web pages for a given endpoint. A valid endpoint includes pokemon, abilities, items, and more.
   #[cfg(feature = "web")]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -10,8 +10,8 @@ pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
 pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
 
-/// Cargo's color style
-/// [source](https://github.com/crate-ci/clap-cargo/blob/master/src/style.rs)
+// Cargo's color style
+// [source](https://github.com/crate-ci/clap-cargo/blob/master/src/style.rs)
 const CARGO_STYLING: Styles = Styles::styled()
   .header(HEADER)
   .usage(USAGE)
@@ -20,6 +20,10 @@ const CARGO_STYLING: Styles = Styles::styled()
   .error(ERROR)
   .valid(VALID)
   .invalid(INVALID);
+
+// ========================================================================================================================
+// CLI Parser and Subcommands
+// ========================================================================================================================
 
 /// Look up pokemon details using PokeAPI using the 'rustemon' wrapper. Note that sometimes pokemon need to be listed
 /// with their forms if the form is distinct enough (e.g. pumkaboo-small or toxtricity-amped). These varieties can be
@@ -93,7 +97,10 @@ pub enum Command {
   WebCmd(WebArgs),
 }
 
-// Arguments for each subcommand
+// ========================================================================================================================
+// Subcommand Arguments
+// ========================================================================================================================
+
 #[derive(Args, Debug)]
 pub struct ListArgs {
   #[arg(help = "name of pokemon species")]
@@ -384,6 +391,10 @@ pub enum DexMode {
   Abilitydex(String),
   Itemdex(String),
 }
+
+// ========================================================================================================================
+// Helper Functions
+// ========================================================================================================================
 
 pub fn get_appname() -> String {
   String::from(Cli::command().get_name())

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -73,23 +73,7 @@ pub enum Command {
 
   /// Look up the gender ratio of a given pokemon species.
   #[command(name = "genders", long_about)]
-  GenderCmd {
-    #[arg(help = "name of pokemon species")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-  },
+  GenderCmd(GenderArgs),
 
   /// Look up the encounters for a given pokemon and version.
   #[command(name = "encounters", long_about)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -65,30 +65,7 @@ pub enum Command {
     about = "Look up the level-up moveset of a given pokemon",
     long_about
   )]
-  MoveCmd {
-    #[arg(help = "name of pokemon")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-
-    #[arg(value_enum, short, long, default_value_t=VersionGroup::ScarletViolet,
-            hide_possible_values=true, help="version group name")]
-    vgroup: VersionGroup,
-
-    #[arg(short, long, help = "request default moveset at given level")]
-    level: Option<i64>,
-  },
+  MoveCmd(MoveArgs),
 
   /// Look up the egg groups of a given pokemon species.
   #[command(name = "eggs", long_about)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -69,23 +69,7 @@ pub enum Command {
 
   /// Look up the egg groups of a given pokemon species.
   #[command(name = "eggs", long_about)]
-  EggCmd {
-    #[arg(help = "name of pokemon species")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-  },
+  EggCmd(EggArgs),
 
   /// Look up the gender ratio of a given pokemon species.
   #[command(name = "genders", long_about)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -93,6 +93,229 @@ pub enum Command {
   WebCmd(WebArgs),
 }
 
+// Arguments for each subcommand
+#[derive(Args, Debug)]
+pub struct ListArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct TypeArgs {
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(short, long = "gen", help = "generation to query")]
+  pub generation: Option<i64>,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(short, help = "recursively check evolution chain")]
+  pub recursive: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct AbilityArgs {
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(short, help = "recursively check evolution chain")]
+  pub recursive: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct MoveArgs {
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(value_enum, short, long, default_value_t=VersionGroup::ScarletViolet,
+          hide_possible_values=true, help="version group name")]
+  pub vgroup: VersionGroup,
+
+  #[arg(short, long, help = "request default moveset at given level")]
+  pub level: Option<i64>,
+}
+
+#[derive(Args, Debug)]
+pub struct EggArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct GenderArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
+#[derive(Args, Debug)]
+pub struct EncounterArgs {
+  #[arg(value_enum, hide_possible_values = true, help = "name of version")]
+  pub version: Version,
+
+  #[arg(help = "name of pokemon")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(short, help = "recursively check evolution chain")]
+  pub recursive: bool,
+
+  #[arg(short, long, help = "condense output by only showing location areas")]
+  pub condensed: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct EvolutionArgs {
+  #[arg(help = "name of pokemon species")]
+  pub pokemon: String,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+
+  #[arg(
+    short,
+    long,
+    help = "hide the names of the pokemon in the evolution chain"
+  )]
+  pub secret: bool,
+
+  #[arg(short, long, help = "show all evolution chains, even outdated ones")]
+  pub all: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct MatchupArgs {
+  #[arg(
+    value_enum,
+    hide_possible_values = true,
+    value_name = "TYPE",
+    help = "name of type"
+  )]
+  pub primary: Type,
+
+  #[arg(
+    value_enum,
+    hide_possible_values = true,
+    value_name = "TYPE",
+    help = "name of optional secondary type"
+  )]
+  pub secondary: Option<Type>,
+
+  #[arg(short, long, help = "print output as a list instead of a table")]
+  pub list: bool,
+
+  #[arg(short, long, help = "skip API requests for formatted names")]
+  pub fast: bool,
+
+  #[arg(value_enum,
+    short = 'L',
+    long,
+    value_name = "LANGUAGE",
+    default_value_t = LanguageId::En,
+    hide_possible_values=true,
+    help = "language ID for API requests for formatted names"
+  )]
+  pub lang: LanguageId,
+}
+
 #[derive(Args, Debug)]
 pub struct WebArgs {
   #[command(flatten)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -90,19 +90,22 @@ pub enum Command {
   /// Open web pages for a given endpoint. A valid endpoint includes pokemon, abilities, items, and more.
   #[cfg(feature = "web")]
   #[command(name = "web", long_about)]
-  WebCmd {
-    #[command(flatten)]
-    endpoint: Endpoints,
+  WebCmd(WebArgs),
+}
 
-    #[arg(short = 'A', long, help = "name of area within region")]
-    area: Option<String>,
+#[derive(Args, Debug)]
+pub struct WebArgs {
+  #[command(flatten)]
+  pub endpoint: Endpoints,
 
-    #[arg(short, long = "gen", help = "optional name of generation to use")]
-    generation: Option<i64>,
+  #[arg(short = 'A', long, help = "name of area within region")]
+  pub area: Option<String>,
 
-    #[arg(short, long, help = "suppress print statements")]
-    quiet: bool,
-  },
+  #[arg(short, long = "gen", help = "optional name of generation to use")]
+  pub generation: Option<i64>,
+
+  #[arg(short, long, help = "suppress print statements")]
+  pub quiet: bool,
 }
 
 #[cfg(feature = "web")]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -46,29 +46,7 @@ pub enum Command {
 
   /// Look up the type(s) of a given pokemon.
   #[command(name = "types", long_about)]
-  TypeCmd {
-    #[arg(help = "name of pokemon")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(short, long = "gen", help = "generation to query")]
-    generation: Option<i64>,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-
-    #[arg(short, help = "recursively check evolution chain")]
-    recursive: bool,
-  },
+  TypeCmd(TypeArgs),
 
   /// Look up the abilities of a given pokemon. If the ability is a hidden ability, it will be
   /// marked accordingly.

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -42,23 +42,7 @@ pub struct Cli {
 pub enum Command {
   /// Look up the varieties of a given pokemon.
   #[command(name = "list", long_about)]
-  ListCmd {
-    #[arg(help = "name of pokemon species")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-  },
+  ListCmd(ListArgs),
 
   /// Look up the type(s) of a given pokemon.
   #[command(name = "types", long_about)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,6 +1,6 @@
-use crate::utils::enums::*;
+use crate::utils::args;
 use clap::builder::styling::{AnsiColor, Effects, Style, Styles};
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
@@ -46,11 +46,11 @@ pub struct Cli {
 pub enum Command {
   /// Look up the varieties of a given pokemon.
   #[command(name = "list", long_about)]
-  ListCmd(ListArgs),
+  ListCmd(args::ListArgs),
 
   /// Look up the type(s) of a given pokemon.
   #[command(name = "types", long_about)]
-  TypeCmd(TypeArgs),
+  TypeCmd(args::TypeArgs),
 
   /// Look up the abilities of a given pokemon. If the ability is a hidden ability, it will be
   /// marked accordingly.
@@ -59,7 +59,7 @@ pub enum Command {
     about = "Look up the abilities of a given pokemon",
     long_about
   )]
-  AbilityCmd(AbilityArgs),
+  AbilityCmd(args::AbilityArgs),
 
   /// Look up the level-up moveset of a given pokemon. If a level is provided
   /// then the four moves at or below the given level are provided. By default, this will
@@ -69,327 +69,32 @@ pub enum Command {
     about = "Look up the level-up moveset of a given pokemon",
     long_about
   )]
-  MoveCmd(MoveArgs),
+  MoveCmd(args::MoveArgs),
 
   /// Look up the egg groups of a given pokemon species.
   #[command(name = "eggs", long_about)]
-  EggCmd(EggArgs),
+  EggCmd(args::EggArgs),
 
   /// Look up the gender ratio of a given pokemon species.
   #[command(name = "genders", long_about)]
-  GenderCmd(GenderArgs),
+  GenderCmd(args::GenderArgs),
 
   /// Look up the encounters for a given pokemon and version.
   #[command(name = "encounters", long_about)]
-  EncounterCmd(EncounterArgs),
+  EncounterCmd(args::EncounterArgs),
 
   /// Look up evolution chain for a given pokemon species.
   #[command(name = "evolutions", long_about)]
-  EvolutionCmd(EvolutionArgs),
+  EvolutionCmd(args::EvolutionArgs),
 
   /// Look up the type weaknesses/resistances for given type(s).
   #[command(name = "matchups", long_about)]
-  MatchupCmd(MatchupArgs),
+  MatchupCmd(args::MatchupArgs),
 
   /// Open web pages for a given endpoint. A valid endpoint includes pokemon, abilities, items, and more.
   #[cfg(feature = "web")]
   #[command(name = "web", long_about)]
-  WebCmd(WebArgs),
-}
-
-// ========================================================================================================================
-// Subcommand Arguments
-// ========================================================================================================================
-
-#[derive(Args, Debug)]
-pub struct ListArgs {
-  #[arg(help = "name of pokemon species")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-}
-
-#[derive(Args, Debug)]
-pub struct TypeArgs {
-  #[arg(help = "name of pokemon")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(short, long = "gen", help = "generation to query")]
-  pub generation: Option<i64>,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-
-  #[arg(short, help = "recursively check evolution chain")]
-  pub recursive: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct AbilityArgs {
-  #[arg(help = "name of pokemon")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-
-  #[arg(short, help = "recursively check evolution chain")]
-  pub recursive: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct MoveArgs {
-  #[arg(help = "name of pokemon")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-
-  #[arg(value_enum, short, long, default_value_t=VersionGroup::ScarletViolet,
-          hide_possible_values=true, help="version group name")]
-  pub vgroup: VersionGroup,
-
-  #[arg(short, long, help = "request default moveset at given level")]
-  pub level: Option<i64>,
-}
-
-#[derive(Args, Debug)]
-pub struct EggArgs {
-  #[arg(help = "name of pokemon species")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-}
-
-#[derive(Args, Debug)]
-pub struct GenderArgs {
-  #[arg(help = "name of pokemon species")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-}
-
-#[derive(Args, Debug)]
-pub struct EncounterArgs {
-  #[arg(value_enum, hide_possible_values = true, help = "name of version")]
-  pub version: Version,
-
-  #[arg(help = "name of pokemon")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-
-  #[arg(short, help = "recursively check evolution chain")]
-  pub recursive: bool,
-
-  #[arg(short, long, help = "condense output by only showing location areas")]
-  pub condensed: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct EvolutionArgs {
-  #[arg(help = "name of pokemon species")]
-  pub pokemon: String,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-
-  #[arg(
-    short,
-    long,
-    help = "hide the names of the pokemon in the evolution chain"
-  )]
-  pub secret: bool,
-
-  #[arg(short, long, help = "show all evolution chains, even outdated ones")]
-  pub all: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct MatchupArgs {
-  #[arg(
-    value_enum,
-    hide_possible_values = true,
-    value_name = "TYPE",
-    help = "name of type"
-  )]
-  pub primary: Type,
-
-  #[arg(
-    value_enum,
-    hide_possible_values = true,
-    value_name = "TYPE",
-    help = "name of optional secondary type"
-  )]
-  pub secondary: Option<Type>,
-
-  #[arg(short, long, help = "print output as a list instead of a table")]
-  pub list: bool,
-
-  #[arg(short, long, help = "skip API requests for formatted names")]
-  pub fast: bool,
-
-  #[arg(value_enum,
-    short = 'L',
-    long,
-    value_name = "LANGUAGE",
-    default_value_t = LanguageId::En,
-    hide_possible_values=true,
-    help = "language ID for API requests for formatted names"
-  )]
-  pub lang: LanguageId,
-}
-
-#[derive(Args, Debug)]
-pub struct WebArgs {
-  #[command(flatten)]
-  pub endpoint: Endpoints,
-
-  #[arg(short = 'A', long, help = "name of area within region")]
-  pub area: Option<String>,
-
-  #[arg(short, long = "gen", help = "optional name of generation to use")]
-  pub generation: Option<i64>,
-
-  #[arg(short, long, help = "suppress print statements")]
-  pub quiet: bool,
-}
-
-#[cfg(feature = "web")]
-#[derive(Args, Debug)]
-#[group(required = true, multiple = false)]
-pub struct Endpoints {
-  #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area"], help = "name of pokemon")]
-  pub pokemon: Option<String>,
-
-  #[arg(short, long, help_heading = "Endpoints", help = "name of region")]
-  pub region: Option<String>,
-
-  #[arg(
-    short,
-    long,
-    help_heading = "Endpoints",
-    conflicts_with = "area",
-    help = "name of move"
-  )]
-  pub move_: Option<String>,
-
-  #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area", "generation"], help = "name of ability")]
-  pub ability: Option<String>,
-
-  #[arg(short, long, help_heading = "Endpoints", conflicts_with_all = ["area", "generation"], help = "name of item")]
-  pub item: Option<String>,
-}
-
-#[cfg(feature = "web")]
-impl Endpoints {
-  pub fn get_mode(&self) -> DexMode {
-    if let Some(name) = &self.pokemon {
-      DexMode::Pokedex(name.clone())
-    } else if let Some(name) = &self.region {
-      DexMode::Pokearth(name.clone())
-    } else if let Some(name) = &self.move_ {
-      DexMode::Attackdex(name.clone())
-    } else if let Some(name) = &self.ability {
-      DexMode::Abilitydex(name.clone())
-    } else if let Some(name) = &self.item {
-      DexMode::Itemdex(name.clone())
-    } else {
-      unreachable!()
-    }
-  }
-}
-
-#[cfg(feature = "web")]
-pub enum DexMode {
-  Pokedex(String),
-  Pokearth(String),
-  Attackdex(String),
-  Abilitydex(String),
-  Itemdex(String),
+  WebCmd(args::WebArgs),
 }
 
 // ========================================================================================================================

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -81,33 +81,7 @@ pub enum Command {
 
   /// Look up evolution chain for a given pokemon species.
   #[command(name = "evolutions", long_about)]
-  EvolutionCmd {
-    #[arg(help = "name of pokemon species")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-
-    #[arg(
-      short,
-      long,
-      help = "hide the names of the pokemon in the evolution chain"
-    )]
-    secret: bool,
-
-    #[arg(short, long, help = "show all evolution chains, even outdated ones")]
-    all: bool,
-  },
+  EvolutionCmd(EvolutionArgs),
 
   /// Look up the type weaknesses/resistances for given type(s).
   #[command(name = "matchups", long_about)]

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -55,26 +55,7 @@ pub enum Command {
     about = "Look up the abilities of a given pokemon",
     long_about
   )]
-  AbilityCmd {
-    #[arg(help = "name of pokemon")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-
-    #[arg(short, help = "recursively check evolution chain")]
-    recursive: bool,
-  },
+  AbilityCmd(AbilityArgs),
 
   /// Look up the level-up moveset of a given pokemon. If a level is provided
   /// then the four moves at or below the given level are provided. By default, this will

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -77,32 +77,7 @@ pub enum Command {
 
   /// Look up the encounters for a given pokemon and version.
   #[command(name = "encounters", long_about)]
-  EncounterCmd {
-    #[arg(value_enum, hide_possible_values = true, help = "name of version")]
-    version: Version,
-
-    #[arg(help = "name of pokemon")]
-    pokemon: String,
-
-    #[arg(short, long, help = "skip API requests for formatted names")]
-    fast: bool,
-
-    #[arg(value_enum,
-      short = 'L',
-      long,
-      value_name = "LANGUAGE",
-      default_value_t = LanguageId::En,
-      hide_possible_values=true,
-      help = "language ID for API requests for formatted names"
-    )]
-    lang: LanguageId,
-
-    #[arg(short, help = "recursively check evolution chain")]
-    recursive: bool,
-
-    #[arg(short, long, help = "condense output by only showing location areas")]
-    condensed: bool,
-  },
+  EncounterCmd(EncounterArgs),
 
   /// Look up evolution chain for a given pokemon species.
   #[command(name = "evolutions", long_about)]


### PR DESCRIPTION
Refactors code to use argument structs to simplify lookup function calls. Split up the `cli.rs` file for easier readability and future additions/maintenance.